### PR TITLE
Fix useFormState typing

### DIFF
--- a/src/hooks/useFormState.hook.ts
+++ b/src/hooks/useFormState.hook.ts
@@ -2,7 +2,7 @@ import { useState } from 'react'
 
 type UpdateState = <T>(
   inputName: string,
-  callbackOrValue?: (event: T) => any | any
+  callbackOrValue?: ((event: T) => any) | any
 ) => (event: T) => void
 
 export const useFormState = <FormType>(formState: FormType) => {


### PR DESCRIPTION
`(event: T) => any | any` is equivalent to `(event: T) => (any | any)` which is equivalent to `(event: T) => any` which is obviously not the correct typing.